### PR TITLE
feat: add RiftBeam Aggregator program label

### DIFF
--- a/program.json
+++ b/program.json
@@ -774,5 +774,9 @@
     "JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4": {
         "name": "Jupiter V6",
         "logo": ""
+    },
+    "DYR2SfXreL4wMPKjWzgWv17r7qHJk3kyp1R7k3MsKkEV": {
+        "name": "RiftBeam Aggregator",
+        "logo": "https://riftbeam.cloud/rb-icon.png"
     }
 }


### PR DESCRIPTION
Adds label for the RiftBeam DEX Aggregator program on Solana mainnet.

- Program: `DYR2SfXreL4wMPKjWzgWv17r7qHJk3kyp1R7k3MsKkEV`
- Name: RiftBeam Aggregator
- Logo: https://riftbeam.cloud/rb-icon.png
- Website: https://riftbeam.cloud